### PR TITLE
Remove Instagram and Facebook usernames

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,8 +26,8 @@ baseurl: "" # the subpath of your site, e.g. /blog
 url: "" # the base hostname & protocol for your site, e.g. http://example.com
 
 github_username:  ameyarya
-instagram_username: _am3y
-facebook_username: amey.arya
+# instagram_username: _am3y
+# facebook_username: amey.arya
 linkedin_username: ameyarya
 
 # Build settings


### PR DESCRIPTION
## Summary
- comment out unused Instagram and Facebook usernames in Jekyll config

## Testing
- `bundle exec jekyll serve --detach` *(fails: undefined method `tainted?` for "en":String)*


------
https://chatgpt.com/codex/tasks/task_e_68a0dce2af04832dbef2faff2e0a0473